### PR TITLE
New script to lookup filenames in pulp3

### DIFF
--- a/cfn
+++ b/cfn
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+## Convert a pulp artifact path to the name of what it contains.
+
+# Convert the long-string filename + its immediate parent dir into a checksum
+longstring="$(echo $1 | rev | cut -f1,2 -d/ | rev | tr -d '/')"
+
+# Grab sourcerpm filename and arch, replace `.src.` in the srpm with `.$arch.`. (yes, this is the most convenient way I can think of doing this in.)
+cd ~postgres && sudo -u postgres psql -t -d pulpcore -c "select rpm_sourcerpm, arch from rpm_package p where \"p\".\"pkgId\" = '$longstring'" | while read pkgname separator arch; do echo ${pkgname//\.src\./.$arch.}; done


### PR DESCRIPTION
On pulp2 we used to be able to understand what a file was by simply looking at its name. Pulp 3 changes this and now we need to query the pulpcore database to understand what each file really holds.
This script (cfn) expects a filepath as argument and returns the RPM filename to stdout:
~~~
$ ./cfn /var/lib/pulp/media/artifact/ab/3349822b7f0631af67750e4ac494e86c456394aa7ce8d4c3d01c9c3a27b877 
ansible-2.9.25-1.el7ae.noarch.rpm
~~~

The script in its current initial form works with RPMs only. Not even metadata are covered but it's quite easy to add that functionality -- I full intend to do it in the future but now I'm in a hurry and I really just need the RPM functionality for the time being.